### PR TITLE
fix: remove client_infos from header

### DIFF
--- a/mjpg-streamer-experimental/plugins/output_http/httpd.c
+++ b/mjpg-streamer-experimental/plugins/output_http/httpd.c
@@ -307,6 +307,12 @@ int unescape(char *string)
 
 #ifdef MANAGMENT
 
+struct {
+    client_info **infos;
+    unsigned int client_count;
+    pthread_mutex_t mutex;
+} client_infos;
+
 /******************************************************************************
 Description.: Adds a new client information struct to the ino list.
 Input Value.: Client IP address as a string

--- a/mjpg-streamer-experimental/plugins/output_http/httpd.h
+++ b/mjpg-streamer-experimental/plugins/output_http/httpd.h
@@ -148,11 +148,6 @@ typedef struct _client_info {
     struct timeval last_take_time;
 } client_info;
 
-struct {
-    client_info **infos;
-    unsigned int client_count;
-    pthread_mutex_t mutex;
-} client_infos;
 
 #endif
 


### PR DESCRIPTION
httpd.h is included in two .c files and they are compiled together 
```
﻿﻿MJPG_STREAMER_PLUGIN_COMPILE(output_http httpd.c output_http.c)
```
